### PR TITLE
Requester ResponseFactory and Response implementations

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Solido\Atlante\Http;
 
-use Closure;
 use Solido\Atlante\Requester\Decorator\DecoratorInterface;
 use Solido\Atlante\Requester\Exception\BadRequestException;
 use Solido\Atlante\Requester\Exception\InvalidRequestException;
@@ -14,7 +13,6 @@ use Solido\Atlante\Requester\Response\BadResponse;
 use Solido\Atlante\Requester\Response\InvalidResponse;
 use Solido\Atlante\Requester\Response\ResponseFactory;
 use Solido\Atlante\Requester\Response\ResponseInterface;
-use Traversable;
 use function http_build_query;
 use function in_array;
 use function is_iterable;
@@ -49,22 +47,6 @@ class Client implements ClientInterface
     public function get(string $path, ?array $headers = null): ResponseInterface
     {
         return $this->request('GET', $path, null, $headers);
-    }
-
-    /**
-     * Performs a merge-patch request to the API service using the PATCH method.
-     *
-     * @param array|string|resource|Closure<string>|Traversable<string>|null $requestData
-     * @param string[]|string[][]|null                                       $headers
-     *
-     * @phpstan-param array|string|resource|Closure(): string|Traversable<string>|null $requestData
-     */
-    public function mergePatch(string $path, $requestData = null, ?array $headers = null): ResponseInterface
-    {
-        $headers = new HeaderBag($headers ?? []);
-        $headers->set('content-type', 'application/merge-patch+json');
-
-        return $this->request('PATCH', $path, $requestData, $headers->all());
     }
 
     /** {@inheritdoc} */

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -4,25 +4,31 @@ declare(strict_types=1);
 
 namespace Solido\Atlante\Http;
 
-use Solido\Atlante\Exception\AccessDeniedHttpException;
-use Solido\Atlante\Exception\BadRequestHttpException;
-use Solido\Atlante\Exception\HttpException;
-use Solido\Atlante\Exception\NotFoundHttpException;
+use Closure;
 use Solido\Atlante\Requester\Decorator\DecoratorInterface;
+use Solido\Atlante\Requester\Exception\BadRequestException;
+use Solido\Atlante\Requester\Exception\InvalidRequestException;
 use Solido\Atlante\Requester\Request;
 use Solido\Atlante\Requester\RequesterInterface;
-use Solido\Atlante\Requester\Response;
-use function assert;
+use Solido\Atlante\Requester\Response\BadResponse;
+use Solido\Atlante\Requester\Response\InvalidResponse;
+use Solido\Atlante\Requester\Response\ResponseFactory;
+use Solido\Atlante\Requester\Response\ResponseInterface;
+use Traversable;
+use function http_build_query;
 use function in_array;
 use function is_iterable;
+use function Safe\json_encode;
+use function strpos;
 
 class Client implements ClientInterface
 {
-    /** @var RequesterInterface */
-    protected $requester;
+    protected RequesterInterface $requester;
 
     /** @var iterable<DecoratorInterface> */
     protected $decorators;
+
+    protected ?ResponseFactory $responseFactory = null;
 
     /**
      * @param iterable<DecoratorInterface>|null $requestDecorators
@@ -34,37 +40,53 @@ class Client implements ClientInterface
     }
 
     /** {@inheritdoc} */
-    public function delete(string $path, ?array $headers = null): Response
+    public function delete(string $path, ?array $headers = null): ResponseInterface
     {
         return $this->request('DELETE', $path, null, $headers);
     }
 
     /** {@inheritdoc} */
-    public function get(string $path, ?array $headers = null): Response
+    public function get(string $path, ?array $headers = null): ResponseInterface
     {
         return $this->request('GET', $path, null, $headers);
     }
 
+    /**
+     * Performs a merge-patch request to the API service using the PATCH method.
+     *
+     * @param array|string|resource|Closure<string>|Traversable<string>|null $requestData
+     * @param string[]|string[][]|null                                       $headers
+     *
+     * @phpstan-param array|string|resource|Closure(): string|Traversable<string>|null $requestData
+     */
+    public function mergePatch(string $path, $requestData = null, ?array $headers = null): ResponseInterface
+    {
+        $headers = new HeaderBag($headers ?? []);
+        $headers->set('content-type', 'application/merge-patch+json');
+
+        return $this->request('PATCH', $path, $requestData, $headers->all());
+    }
+
     /** {@inheritdoc} */
-    public function post(string $path, $requestData = null, ?array $headers = null): Response
+    public function post(string $path, $requestData = null, ?array $headers = null): ResponseInterface
     {
         return $this->request('POST', $path, $requestData, $headers);
     }
 
     /** {@inheritdoc} */
-    public function put(string $path, $requestData = null, ?array $headers = null): Response
+    public function put(string $path, $requestData = null, ?array $headers = null): ResponseInterface
     {
         return $this->request('PUT', $path, $requestData, $headers);
     }
 
     /** {@inheritdoc} */
-    public function patch(string $path, $requestData = null, ?array $headers = null): Response
+    public function patch(string $path, $requestData = null, ?array $headers = null): ResponseInterface
     {
         return $this->request('PATCH', $path, $requestData, $headers);
     }
 
     /** {@inheritdoc} */
-    public function request(string $method, string $path, $requestData = null, ?array $headers = null): Response
+    public function request(string $method, string $path, $requestData = null, ?array $headers = null): ResponseInterface
     {
         if (in_array($method, ['GET', 'HEAD', 'DELETE'])) {
             $requestData = null;
@@ -80,7 +102,21 @@ class Client implements ClientInterface
         }
 
         $body = $request->getBody();
-        assert(! is_iterable($body));
+        if (is_iterable($body)) {
+            $contentType = $headerBag->get('Content-type');
+            if ($contentType === null) {
+                $contentType = 'application/json';
+                $headerBag = new HeaderBag($request->getHeaders() ?? []);
+                $headerBag->set('Content-type', $contentType);
+                $request = new Request($request->getMethod(), $request->getUrl(), $headerBag->all(), $request->getBody());
+            }
+
+            if (strpos($contentType, 'application/json') === 0) {
+                $body = json_encode($body);
+            } else {
+                $body = http_build_query($body);
+            }
+        }
 
         $response = $this->requester->request(
             $request->getMethod(),
@@ -94,22 +130,21 @@ class Client implements ClientInterface
         return $response;
     }
 
-    protected static function filterResponse(Response $response): void
+    public function setResponseFactory(?ResponseFactory $factory): self
     {
-        $statusCode = $response->getStatus();
-        if (200 <= $statusCode && 300 > $statusCode) {
-            return;
+        $this->responseFactory = $factory;
+
+        return $this;
+    }
+
+    protected static function filterResponse(ResponseInterface $response): void
+    {
+        if ($response instanceof BadResponse) {
+            throw new BadRequestException($response);
         }
 
-        switch ($statusCode) {
-            case 404:
-                throw new NotFoundHttpException();
-            case 400:
-                throw new BadRequestHttpException();
-            case 403:
-                throw new AccessDeniedHttpException('Forbidden');
-            default:
-                throw new HttpException($statusCode, 'Response is not ok: status code ' . $statusCode);
+        if ($response instanceof InvalidResponse) {
+            throw new InvalidRequestException($response);
         }
     }
 }

--- a/src/Http/ClientInterface.php
+++ b/src/Http/ClientInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Solido\Atlante\Http;
 
 use Closure;
-use Solido\Atlante\Requester\Response;
+use Solido\Atlante\Requester\Response\ResponseInterface;
 use Traversable;
 
 interface ClientInterface
@@ -18,21 +18,21 @@ interface ClientInterface
      *
      * @phpstan-param array|string|resource|Closure(): string|Traversable<string>|null $requestData
      */
-    public function request(string $method, string $path, $requestData = null, ?array $headers = null): Response;
+    public function request(string $method, string $path, $requestData = null, ?array $headers = null): ResponseInterface;
 
     /**
      * Performs a request to the API service using a DELETE method.
      *
      * @param string[]|string[][]|null $headers
      */
-    public function delete(string $path, ?array $headers = null): Response;
+    public function delete(string $path, ?array $headers = null): ResponseInterface;
 
     /**
      * Performs a request to the API service using a GET method.
      *
      * @param string[]|string[][]|null $headers
      */
-    public function get(string $path, ?array $headers = null): Response;
+    public function get(string $path, ?array $headers = null): ResponseInterface;
 
     /**
      * Performs a request to the API service using a POST method.
@@ -42,7 +42,7 @@ interface ClientInterface
      *
      * @phpstan-param array|string|resource|Closure(): string|Traversable<string>|null $requestData
      */
-    public function post(string $path, $requestData = null, ?array $headers = null): Response;
+    public function post(string $path, $requestData = null, ?array $headers = null): ResponseInterface;
 
     /**
      * Performs a request to the API service using a PUT method.
@@ -52,7 +52,7 @@ interface ClientInterface
      *
      * @phpstan-param array|string|resource|Closure(): string|Traversable<string>|null $requestData
      */
-    public function put(string $path, $requestData = null, ?array $headers = null): Response;
+    public function put(string $path, $requestData = null, ?array $headers = null): ResponseInterface;
 
     /**
      * Performs a request to the API service using a PATCH method.
@@ -62,5 +62,5 @@ interface ClientInterface
      *
      * @phpstan-param array|string|resource|Closure(): string|Traversable<string>|null $requestData
      */
-    public function patch(string $path, $requestData = null, ?array $headers = null): Response;
+    public function patch(string $path, $requestData = null, ?array $headers = null): ResponseInterface;
 }

--- a/src/Requester/Decorator/Authentication/OAuth/ClientTokenAuthenticator.php
+++ b/src/Requester/Decorator/Authentication/OAuth/ClientTokenAuthenticator.php
@@ -8,7 +8,7 @@ use Solido\Atlante\Exception\NoTokenAvailableException;
 use Solido\Atlante\Requester\Decorator\DecoratorInterface;
 use Solido\Atlante\Requester\Request;
 use Solido\Atlante\Requester\RequesterInterface;
-use Solido\Atlante\Requester\Response;
+use Solido\Atlante\Requester\Response\ResponseInterface;
 use Solido\Atlante\Storage\StorageInterface;
 use function assert;
 use function http_build_query;
@@ -66,8 +66,8 @@ class ClientTokenAuthenticator implements DecoratorInterface
         [$body, $headers] = $this->buildTokenRequest([ 'grant_type' => 'client_credentials' ]);
         $response = $this->request($body, $headers);
 
-        if ($response->getStatus() !== 200) {
-            throw new NoTokenAvailableException(sprintf('Client credentials token returned status %d', $response->getStatus()));
+        if ($response->getStatusCode() !== 200) {
+            throw new NoTokenAvailableException(sprintf('Client credentials token returned status %d', $response->getStatusCode()));
         }
 
         $content = $response->getData();
@@ -107,7 +107,7 @@ class ClientTokenAuthenticator implements DecoratorInterface
      * @param array<string, string>|null $body
      * @param array<string, string|string[]> $headers
      */
-    private function request(?array $body, array $headers): Response
+    private function request(?array $body, array $headers): ResponseInterface
     {
         if ($this->dataEncoding === 'json') {
             $headers['Content-Type'] = 'application/json';

--- a/src/Requester/Decorator/BodyConverterDecorator.php
+++ b/src/Requester/Decorator/BodyConverterDecorator.php
@@ -7,12 +7,15 @@ namespace Solido\Atlante\Requester\Decorator;
 use Closure;
 use Solido\Atlante\Http\HeaderBag;
 use Solido\Atlante\Requester\Request;
+use UnexpectedValueException;
+use function http_build_query;
 use function is_callable;
 use function is_iterable;
 use function is_resource;
 use function is_string;
-use function json_encode;
-use const JSON_THROW_ON_ERROR;
+use function Safe\json_encode;
+use function Safe\sprintf;
+use function strpos;
 
 class BodyConverterDecorator implements DecoratorInterface
 {
@@ -24,9 +27,26 @@ class BodyConverterDecorator implements DecoratorInterface
         $body = $body === null || is_string($body) ? $body : function () use ($body, $headers) {
             $body = $this->prepare($body);
 
-            if (! is_string($body)) {
-                $body = json_encode($body, JSON_THROW_ON_ERROR);
-                $headers->set('content-type', 'application/json', true);
+            if (! is_string($body) && $body !== null) {
+                $contentType = $headers->get('content-type');
+                // add content-type if not specified
+                if ($contentType === null) {
+                    $contentType = 'application/json';
+                    $headers->set('content-type', $contentType);
+                }
+
+                if (strpos($contentType, 'application/json') === 0) {
+                    $body = json_encode($body);
+                } elseif (strpos($contentType, 'application/x-www-form-urlencoded') === 0) {
+                    $body = http_build_query($body);
+                } else {
+                    throw new UnexpectedValueException(
+                        sprintf(
+                            'Unable to convert Request content body: expected "application/json" or "application/x-www-form-urlencoded" `content-type` header, "%s" given',
+                            $contentType
+                        )
+                    );
+                }
             }
 
             return $body;

--- a/src/Requester/Decorator/BodyConverterDecorator.php
+++ b/src/Requester/Decorator/BodyConverterDecorator.php
@@ -5,18 +5,30 @@ declare(strict_types=1);
 namespace Solido\Atlante\Requester\Decorator;
 
 use Closure;
+use InvalidArgumentException;
+use ReflectionFunction;
 use Solido\Atlante\Http\HeaderBag;
 use Solido\Atlante\Requester\Request;
 use UnexpectedValueException;
+use function get_debug_type;
 use function http_build_query;
+use function is_array;
 use function is_callable;
 use function is_iterable;
 use function is_resource;
 use function is_string;
 use function Safe\json_encode;
 use function Safe\sprintf;
+use function stream_get_meta_data;
 use function strpos;
+use const PHP_QUERY_RFC1738;
 
+/**
+ * Ensure that the decorated Request has a string|null|\Closure<string>|resource<stream> body type.
+ *
+ * This decorator also changes Request headers accordingly if an iterable body is
+ * given.
+ */
 class BodyConverterDecorator implements DecoratorInterface
 {
     public function decorate(Request $request): Request
@@ -24,56 +36,85 @@ class BodyConverterDecorator implements DecoratorInterface
         $body = $request->getBody();
         $headers = new HeaderBag($request->getHeaders());
 
-        $body = $body === null || is_string($body) ? $body : function () use ($body, $headers) {
-            $body = $this->prepare($body);
+        if ($body !== null && ! is_string($body)) {
+            $doHandle = function () use ($body, $headers) {
+                $body = $this->prepare($body);
 
-            if (! is_string($body) && $body !== null) {
-                $contentType = $headers->get('content-type');
-                // add content-type if not specified
-                if ($contentType === null) {
-                    $contentType = 'application/json';
-                    $headers->set('content-type', $contentType);
+                if (is_iterable($body)) {
+                    $body = self::encodeIterable($body, $headers);
                 }
 
-                if (strpos($contentType, 'application/json') === 0) {
-                    $body = json_encode($body);
-                } elseif (strpos($contentType, 'application/x-www-form-urlencoded') === 0) {
-                    $body = http_build_query($body);
-                } else {
-                    throw new UnexpectedValueException(
-                        sprintf(
-                            'Unable to convert Request content body: expected "application/json" or "application/x-www-form-urlencoded" `content-type` header, "%s" given',
-                            $contentType
-                        )
-                    );
+                return $body;
+            };
+
+            if (is_callable($body)) {
+                if (! $body instanceof Closure) {
+                    $body = Closure::fromCallable($body);
                 }
+
+                $refl = new ReflectionFunction($body);
+                $returnType = $refl->getReturnType();
+                // @phpstan-ignore-next-line
+                if ($returnType === null || $returnType->getName() !== 'string') {
+                    $body = $doHandle;
+                }
+            } elseif (! is_resource($body) || ! is_array(@stream_get_meta_data($body))) {
+                $body = $doHandle;
             }
-
-            return $body;
-        };
+        }
 
         return new Request($request->getMethod(), $request->getUrl(), $headers->all(), $body);
     }
 
     /**
+     * @param iterable<string> $body
+     */
+    private static function encodeIterable($body, HeaderBag $headers): string
+    {
+        $contentType = $headers->get('content-type');
+        // add content-type if not specified
+        if ($contentType === null) {
+            $contentType = 'application/json';
+            $headers->set('content-type', $contentType);
+        }
+
+        if (strpos($contentType, 'application/json') === 0) {
+            $body = json_encode($body);
+        } elseif (strpos($contentType, 'application/x-www-form-urlencoded') === 0) {
+            $body = http_build_query($body, '', '&', PHP_QUERY_RFC1738);
+        } else {
+            throw new UnexpectedValueException(
+                sprintf(
+                    'Unable to convert Request content body: expected "application/json" or "application/x-www-form-urlencoded" `content-type` header, "%s" given',
+                    $contentType
+                )
+            );
+        }
+
+        return $body;
+    }
+
+    /**
      * @param array|string|resource|Closure|iterable<string>|null $body
      *
-     * @return array<mixed, mixed>|string|null
+     * @return array<mixed, mixed>|resource|string|Closure<string>|null
      *
      * @phpstan-param array|string|resource|Closure(): string|iterable<string>|null $body
+     * @phpstan-return array<mixed, mixed>|resource|string|Closure(): string|null
      */
     private function prepare($body)
     {
-        if ($body === null) {
-            return null;
+        if ($body === null || is_string($body)) {
+            return $body;
         }
 
         if (is_callable($body)) {
             return $this->prepare($body());
         }
 
-        if (is_resource($body)) {
-            return (string) $body;
+        // if it's a valid stream resource
+        if (is_resource($body) && is_array(@stream_get_meta_data($body))) {
+            return $body;
         }
 
         if (is_iterable($body)) {
@@ -82,9 +123,9 @@ class BodyConverterDecorator implements DecoratorInterface
                 $iterated[$k] = $this->prepare($field);
             }
 
-            $body = $iterated;
+            return $iterated;
         }
 
-        return $body;
+        throw new InvalidArgumentException(sprintf('Argument #0 passed to %s has to be null, string, stream resource, iterable or callable, "%s" given', __METHOD__, get_debug_type($body)));
     }
 }

--- a/src/Requester/Exception/AbstractException.php
+++ b/src/Requester/Exception/AbstractException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\Atlante\Requester\Exception;
+
+use RuntimeException;
+use Solido\Atlante\Requester\Response\ResponseInterface;
+
+abstract class AbstractException extends RuntimeException
+{
+    protected ResponseInterface $response;
+
+    public function __construct(ResponseInterface $response)
+    {
+        $this->response = $response;
+    }
+
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Requester/Exception/BadRequestException.php
+++ b/src/Requester/Exception/BadRequestException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\Atlante\Requester\Exception;
+
+use Solido\Atlante\Requester\Response\BadResponse;
+use Solido\Atlante\Requester\Response\ResponseInterface;
+
+class BadRequestException extends AbstractException
+{
+    /** @var BadResponse */
+    protected ResponseInterface $response;
+
+    public function __construct(BadResponse $response)
+    {
+        $this->response = $response;
+    }
+
+    public function getResponse(): BadResponse
+    {
+        return $this->response;
+    }
+}

--- a/src/Requester/Exception/InvalidRequestException.php
+++ b/src/Requester/Exception/InvalidRequestException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\Atlante\Requester\Exception;
+
+use Solido\Atlante\Requester\Response\InvalidResponse;
+use Solido\Atlante\Requester\Response\ResponseInterface;
+
+class InvalidRequestException extends AbstractException
+{
+    /** @var InvalidResponse */
+    protected ResponseInterface $response;
+
+    public function __construct(InvalidResponse $response)
+    {
+        $this->response = $response;
+    }
+
+    public function getResponse(): InvalidResponse
+    {
+        return $this->response;
+    }
+}

--- a/src/Requester/MockRequester.php
+++ b/src/Requester/MockRequester.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\Atlante\Requester;
+
+use RuntimeException;
+use Solido\Atlante\Requester\Response\ResponseInterface;
+use function array_shift;
+
+final class MockRequester implements RequesterInterface
+{
+    /** @var ResponseInterface[] */
+    private array $responses = [];
+
+    /**
+     * Schedule Responses in advance.
+     */
+    public function foresee(ResponseInterface ...$responses): self
+    {
+        $this->responses = $responses;
+
+        return $this;
+    }
+
+    /**
+     * Returns a scheduled Response from a FIFO queue.
+     *
+     * {@inheritdoc}
+     */
+    public function request(string $method, string $uri, array $headers, $requestData = null): ResponseInterface
+    {
+        $response = array_shift($this->responses);
+        if ($response === null) {
+            throw new RuntimeException('Empty response list');
+        }
+
+        return $response;
+    }
+}

--- a/src/Requester/PsrClientRequester.php
+++ b/src/Requester/PsrClientRequester.php
@@ -7,6 +7,8 @@ namespace Solido\Atlante\Requester;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Solido\Atlante\Requester\Response\ResponseFactoryInterface;
+use Solido\Atlante\Requester\Response\ResponseInterface;
 use function is_callable;
 use function is_resource;
 
@@ -15,18 +17,20 @@ class PsrClientRequester implements RequesterInterface
     private ClientInterface $client;
     private RequestFactoryInterface $requestFactory;
     private StreamFactoryInterface $streamFactory;
+    private ResponseFactoryInterface $responseFactory;
 
-    public function __construct(ClientInterface $client, RequestFactoryInterface $requestFactory, StreamFactoryInterface $streamFactory)
+    public function __construct(ClientInterface $client, RequestFactoryInterface $requestFactory, StreamFactoryInterface $streamFactory, ResponseFactoryInterface $responseFactory)
     {
         $this->client = $client;
         $this->requestFactory = $requestFactory;
         $this->streamFactory = $streamFactory;
+        $this->responseFactory = $responseFactory;
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    public function request(string $method, string $uri, array $headers, $requestData = null): Response
+    public function request(string $method, string $uri, array $headers, $requestData = null): ResponseInterface
     {
         $request = $this->requestFactory->createRequest($method, $uri);
         foreach ($headers as $key => $value) {
@@ -46,6 +50,6 @@ class PsrClientRequester implements RequesterInterface
 
         $response = $this->client->sendRequest($request);
 
-        return Response::fromResponse($response);
+        return $this->responseFactory->fromResponse($response);
     }
 }

--- a/src/Requester/PsrClientRequester.php
+++ b/src/Requester/PsrClientRequester.php
@@ -7,6 +7,7 @@ namespace Solido\Atlante\Requester;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Solido\Atlante\Requester\Response\ResponseFactory;
 use Solido\Atlante\Requester\Response\ResponseFactoryInterface;
 use Solido\Atlante\Requester\Response\ResponseInterface;
 use function is_callable;
@@ -19,12 +20,12 @@ class PsrClientRequester implements RequesterInterface
     private StreamFactoryInterface $streamFactory;
     private ResponseFactoryInterface $responseFactory;
 
-    public function __construct(ClientInterface $client, RequestFactoryInterface $requestFactory, StreamFactoryInterface $streamFactory, ResponseFactoryInterface $responseFactory)
+    public function __construct(ClientInterface $client, RequestFactoryInterface $requestFactory, StreamFactoryInterface $streamFactory, ?ResponseFactoryInterface $responseFactory = null)
     {
         $this->client = $client;
         $this->requestFactory = $requestFactory;
         $this->streamFactory = $streamFactory;
-        $this->responseFactory = $responseFactory;
+        $this->responseFactory = $responseFactory ?? new ResponseFactory();
     }
 
     /**

--- a/src/Requester/Request.php
+++ b/src/Requester/Request.php
@@ -44,7 +44,7 @@ class Request
     }
 
     /**
-     * @return array|string|resource|Closure|iterable<string>|null
+     * @return array|string|resource|Closure<string>|iterable<string>|null
      *
      * @phpstan-return array|string|resource|Closure(): string|iterable<string>|null
      */

--- a/src/Requester/RequesterInterface.php
+++ b/src/Requester/RequesterInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Solido\Atlante\Requester;
 
+use Solido\Atlante\Requester\Response\ResponseInterface;
+
 interface RequesterInterface
 {
     /**
@@ -11,7 +13,7 @@ interface RequesterInterface
      * Returns a response with parsed data, if no error is present.
      *
      * @param array<string, string|string[]> $headers
-     * @param callable|string|resource|null $requestData
+     * @param callable|string|resource|null  $requestData
      */
-    public function request(string $method, string $uri, array $headers, $requestData = null): Response;
+    public function request(string $method, string $uri, array $headers, $requestData = null): ResponseInterface;
 }

--- a/src/Requester/Response/AbstractResponse.php
+++ b/src/Requester/Response/AbstractResponse.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\Atlante\Requester\Response;
+
+abstract class AbstractResponse implements ResponseInterface
+{
+    /** @var object|string */
+    protected $data;
+    protected int $statusCode;
+
+    /**
+     * @param object|string $data
+     */
+    public function __construct(int $statusCode, $data)
+    {
+        $this->statusCode = $statusCode;
+        $this->data = $data;
+    }
+
+    /**
+     * @return object|string
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+}

--- a/src/Requester/Response/BadResponse.php
+++ b/src/Requester/Response/BadResponse.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\Atlante\Requester\Response;
+
+use function assert;
+
+class BadResponse extends AbstractResponse
+{
+    private const HTTP_STATUS = 400;
+
+    /** @var BadResponsePropertyTree */
+    protected $data;
+
+    /**
+     * @param object|array<string,mixed>|string $data
+     */
+    public function __construct($data)
+    {
+        $data = BadResponsePropertyTree::parse($data);
+
+        parent::__construct(self::HTTP_STATUS, $data);
+    }
+
+    /**
+     * Alias of getData().
+     */
+    public function getErrors(): BadResponsePropertyTree
+    {
+        return $this->getData();
+    }
+
+    public function getData(): BadResponsePropertyTree
+    {
+        $data = parent::getData();
+        assert($data instanceof BadResponsePropertyTree);
+
+        return $data;
+    }
+}

--- a/src/Requester/Response/BadResponsePropertyTree.php
+++ b/src/Requester/Response/BadResponsePropertyTree.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\Atlante\Requester\Response;
+
+use InvalidArgumentException;
+use function array_map;
+use function is_string;
+
+final class BadResponsePropertyTree
+{
+    /** @var string[] */
+    private array $errors = [];
+
+    private string $name;
+
+    /** @var static[] */
+    private array $children = [];
+
+    /**
+     * @param object|array<string,mixed>|string $content
+     */
+    public static function parse($content): self
+    {
+        $obj = new self();
+
+        if (is_string($content)) {
+            throw new InvalidArgumentException('Unexpcted response type, object or array expected, string given');
+        }
+
+        $content = (array) $content;
+
+        $errors = $content['errors'] ?? null;
+        if ($errors === null) {
+            throw new InvalidArgumentException('Unable to parse missing `errors`');
+        }
+
+        $obj->errors = $errors;
+
+        $name = $content['name'] ?? null;
+        if ($name === null) {
+            throw new InvalidArgumentException('Missing `name` property');
+        }
+
+        $obj->name = $name;
+
+        $obj->children = array_map([$obj, 'parse'], $content['children'] ?? []);
+
+        return $obj;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /** @return string[] */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /** @return self[] */
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    /**
+     * @internal Use static `parse` method instead
+     */
+    private function __construct()
+    {
+    }
+}

--- a/src/Requester/Response/InvalidResponse.php
+++ b/src/Requester/Response/InvalidResponse.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\Atlante\Requester\Response;
+
+class InvalidResponse extends AbstractResponse
+{
+}

--- a/src/Requester/Response/Response.php
+++ b/src/Requester/Response/Response.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\Atlante\Requester\Response;
+
+class Response extends AbstractResponse
+{
+}

--- a/src/Requester/Response/ResponseFactory.php
+++ b/src/Requester/Response/ResponseFactory.php
@@ -2,67 +2,64 @@
 
 declare(strict_types=1);
 
-namespace Solido\Atlante\Requester;
+namespace Solido\Atlante\Requester\Response;
 
 use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 use Safe\Exceptions\JsonException;
 use Solido\Atlante\Http\HeaderBag;
 use Symfony\Contracts\HttpClient\ResponseInterface as SymfonyHttpClientResponse;
 use TypeError;
+use function assert;
 use function get_debug_type;
+use function is_object;
+use function is_string;
 use function Safe\json_decode;
 use function Safe\sprintf;
 use function strpos;
 
-class Response
+class ResponseFactory implements ResponseFactoryInterface
 {
-    /** @var string|object */
-    private $data;
-    private int $status;
-
     /**
      * @param PsrResponseInterface|SymfonyHttpClientResponse $response
      */
-    public static function fromResponse($response): self
+    public function fromResponse($response): ResponseInterface
     {
-        if ($response instanceof PsrResponseInterface || $response instanceof SymfonyHttpClientResponse) {
-            return new self($response);
+        $statusCode = $response->getStatusCode();
+        $data = static::decodeData($response);
+
+        if (is_object($data)) {
+            if ($statusCode < 300 && $statusCode >= 200) {
+                return new Response($statusCode, $data);
+            }
+
+            if ($statusCode === 400) {
+                return new BadResponse($data);
+            }
         }
 
-        throw new TypeError(sprintf('Argument 1 passed to %s has to be an instance of Psr\Http\Message\ResponseInterface or Symfony\Contracts\HttpClient\ResponseInterface, %s passed', __METHOD__, get_debug_type($response)));
-    }
-
-    /** @return string|object */
-    public function getData()
-    {
-        return $this->data;
-    }
-
-    public function getStatus(): int
-    {
-        return $this->status;
+        return new InvalidResponse($statusCode, $data);
     }
 
     /**
      * @param PsrResponseInterface|SymfonyHttpClientResponse $response
+     *
+     * @return object|string
      */
-    private function __construct($response)
+    protected static function decodeData($response)
     {
-        $this->status = $response->getStatusCode();
         if ($response instanceof PsrResponseInterface) {
             $data = (string) $response->getBody();
-            $headers = $response->getHeaders();
+            $headers = new HeaderBag($response->getHeaders());
         } elseif ($response instanceof SymfonyHttpClientResponse) {
             $data = $response->getContent(false);
-            $headers = $response->getHeaders(false);
+            $headers = new HeaderBag($response->getHeaders(false));
         } else {
             throw new TypeError(sprintf('Argument 1 passed to %s has to be an instance of Psr\Http\Message\ResponseInterface or Symfony\Contracts\HttpClient\ResponseInterface, %s passed', __METHOD__, get_debug_type($response)));
         }
 
-        $headers = new HeaderBag($headers);
         $contentType = $headers->get('content-type', 'text/html');
-
-        if ($contentType !== null && strpos($contentType, 'application/json') === 0) {
+        assert(is_string($contentType));
+        if (strpos('application/json', $contentType) === 0) {
             try {
                 $data = json_decode($data, false);
             } catch (JsonException $e) {
@@ -70,6 +67,6 @@ class Response
             }
         }
 
-        $this->data = $data;
+        return $data;
     }
 }

--- a/src/Requester/Response/ResponseFactoryInterface.php
+++ b/src/Requester/Response/ResponseFactoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\Atlante\Requester\Response;
+
+use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface as SymfonyHttpClientResponse;
+
+interface ResponseFactoryInterface
+{
+    /**
+     * @param PsrResponseInterface|SymfonyHttpClientResponse $response
+     */
+    public function fromResponse($response): ResponseInterface;
+}

--- a/src/Requester/Response/ResponseInterface.php
+++ b/src/Requester/Response/ResponseInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\Atlante\Requester\Response;
+
+interface ResponseInterface
+{
+    /**
+     * Returns the API response content.
+     *
+     * @return object|string
+     */
+    public function getData();
+
+    /**
+     * Gets the HTTP status code of the response.
+     */
+    public function getStatusCode(): int;
+}

--- a/src/Requester/SymfonyHttpClientRequester.php
+++ b/src/Requester/SymfonyHttpClientRequester.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Solido\Atlante\Requester;
 
+use Solido\Atlante\Requester\Response\ResponseFactory;
 use Solido\Atlante\Requester\Response\ResponseFactoryInterface;
 use Solido\Atlante\Requester\Response\ResponseInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -13,10 +14,10 @@ class SymfonyHttpClientRequester implements RequesterInterface
     private HttpClientInterface $client;
     private ResponseFactoryInterface $responseFactory;
 
-    public function __construct(HttpClientInterface $client, ResponseFactoryInterface $responseFactory)
+    public function __construct(HttpClientInterface $client, ?ResponseFactoryInterface $responseFactory = null)
     {
         $this->client = $client;
-        $this->responseFactory = $responseFactory;
+        $this->responseFactory = $responseFactory ?? new ResponseFactory();
     }
 
     /**

--- a/src/Requester/SymfonyHttpClientRequester.php
+++ b/src/Requester/SymfonyHttpClientRequester.php
@@ -4,27 +4,31 @@ declare(strict_types=1);
 
 namespace Solido\Atlante\Requester;
 
+use Solido\Atlante\Requester\Response\ResponseFactoryInterface;
+use Solido\Atlante\Requester\Response\ResponseInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class SymfonyHttpClientRequester implements RequesterInterface
 {
     private HttpClientInterface $client;
+    private ResponseFactoryInterface $responseFactory;
 
-    public function __construct(HttpClientInterface $client)
+    public function __construct(HttpClientInterface $client, ResponseFactoryInterface $responseFactory)
     {
         $this->client = $client;
+        $this->responseFactory = $responseFactory;
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    public function request(string $method, string $uri, array $headers, $requestData = null): Response
+    public function request(string $method, string $uri, array $headers, $requestData = null): ResponseInterface
     {
         $response = $this->client->request($method, $uri, [
             'headers' => $headers,
             'body' => $requestData,
         ]);
 
-        return Response::fromResponse($response);
+        return $this->responseFactory->fromResponse($response);
     }
 }


### PR DESCRIPTION
Add a `ResponseFactory` to decouple even more `Response` generation process (parsing and so on).
Introduces also a `MockRequester` to schedule responses (useful to test other components via dependency injection).

A few considerations:
1) `ResponseFactory::fromResponse` now expects a valid response "format" (instance of an object) and will throw and `InvalidResponse` otherwise. It's a strong assumption about this tool usages because it will works out-of-the-box with other Solido's tools (eg dto-management) but it can be easily replaced implementing the factory interface for other usages

2) I saw that the Client `mergePatch` helper method has been removed. At the moment has been re-added **only** to the concrete Client implementation as it's pretty basic and can be useful, especially on a Solido's api infrastructure
