### PR TITLE
Minor unit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "thecodingmachine/safe": "^1.1"
     },
     "require-dev": {
+        "jangregor/phpstan-prophecy": "^0.8.0",
         "laminas/laminas-diactoros": "^2.3",
         "phpunit/phpunit": "^8.1|^9.0",
         "psr/cache": "^1.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
     - vendor/solido/php-coding-standards/phpstan.neon
+    - vendor/jangregor/phpstan-prophecy/extension.neon
 parameters:
     treatPhpDocTypesAsCertain: false

--- a/src/Requester/Decorator/AcceptFallbackDecorator.php
+++ b/src/Requester/Decorator/AcceptFallbackDecorator.php
@@ -19,7 +19,9 @@ class AcceptFallbackDecorator implements DecoratorInterface
     public function decorate(Request $request): Request
     {
         $headers = new HeaderBag($request->getHeaders());
-        $headers->set('accept', $this->accept, true);
+        if (! $headers->has('accept')) {
+            $headers->set('accept', $this->accept, true);
+        }
 
         return new Request($request->getMethod(), $request->getUrl(), $headers->all(), $request->getBody());
     }

--- a/src/Requester/Response/BadResponsePropertyTree.php
+++ b/src/Requester/Response/BadResponsePropertyTree.php
@@ -6,7 +6,10 @@ namespace Solido\Atlante\Requester\Response;
 
 use InvalidArgumentException;
 use function array_map;
+use function get_debug_type;
+use function is_array;
 use function is_string;
+use function Safe\sprintf;
 
 final class BadResponsePropertyTree
 {
@@ -26,14 +29,18 @@ final class BadResponsePropertyTree
         $obj = new self();
 
         if (is_string($content)) {
-            throw new InvalidArgumentException('Unexpcted response type, object or array expected, string given');
+            throw new InvalidArgumentException('Unexpected response type, object or array expected, string given');
         }
 
         $content = (array) $content;
 
         $errors = $content['errors'] ?? null;
         if ($errors === null) {
-            throw new InvalidArgumentException('Unable to parse missing `errors`');
+            throw new InvalidArgumentException('Unable to parse missing `errors` property');
+        }
+
+        if (! is_array($errors)) {
+            throw new InvalidArgumentException(sprintf('Invalid `errors` property type, expected array, %s given', get_debug_type($errors)));
         }
 
         $obj->errors = $errors;
@@ -43,9 +50,18 @@ final class BadResponsePropertyTree
             throw new InvalidArgumentException('Missing `name` property');
         }
 
+        if (! is_string($name)) {
+            throw new InvalidArgumentException(sprintf('Invalid `name` property type, expected string, %s given', get_debug_type($name)));
+        }
+
         $obj->name = $name;
 
-        $obj->children = array_map([$obj, 'parse'], $content['children'] ?? []);
+        $children = $content['children'] ?? [];
+        if (! is_array($children)) {
+            throw new InvalidArgumentException(sprintf('Invalid `children` property type, expected array, %s given', get_debug_type($children)));
+        }
+
+        $obj->children = array_map([$obj, 'parse'], $children);
 
         return $obj;
     }

--- a/src/Requester/Response/ResponseFactory.php
+++ b/src/Requester/Response/ResponseFactory.php
@@ -24,8 +24,8 @@ class ResponseFactory implements ResponseFactoryInterface
      */
     public function fromResponse($response): ResponseInterface
     {
-        $statusCode = $response->getStatusCode();
         $data = static::decodeData($response);
+        $statusCode = $response->getStatusCode();
 
         if (is_object($data)) {
             if ($statusCode < 300 && $statusCode >= 200) {

--- a/tests/Requester/Decorator/AcceptFallbackDecoratorTest.php
+++ b/tests/Requester/Decorator/AcceptFallbackDecoratorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Solido\Atlante\Tests\Requester\Decorator;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use Solido\Atlante\Requester\Decorator\AcceptFallbackDecorator;
+use Solido\Atlante\Requester\Request;
+
+class AcceptFallbackDecoratorTest extends TestCase
+{
+    /**
+     * @param array<string, mixed>|null $given
+     * @param array<string,mixed> $expected
+     *
+     * @dataProvider provideDecorationCases
+     */
+    public function testDecoration(?string $fallback, ?array $given, array $expected): void
+    {
+        $decorator = new AcceptFallbackDecorator($fallback);
+        $decorated = $decorator->decorate(new Request('GET', '/example.com', $given, ''));
+
+        $headers = $decorated->getHeaders();
+
+        self::assertEquals($expected, $headers);
+    }
+
+    public static function provideDecorationCases(): Generator
+    {
+        yield [null, [],['accept' => ['application/json']]];
+        yield [null, null, ['accept' => ['application/json']]];
+        yield [null, ['foo' => ['bar']],['accept' => ['application/json'],'foo' => ['bar']]];
+        yield [null, ['accept' => ['text/html']],['accept' => ['text/html']]];
+
+        yield ['application/xml', [], ['accept' => ['application/xml']]];
+        yield ['application/xml', ['accept' => ['text/html']],['accept' => ['text/html']]];
+    }
+}

--- a/tests/Requester/Decorator/Authentication/HttpBasicAuthenticatorTest.php
+++ b/tests/Requester/Decorator/Authentication/HttpBasicAuthenticatorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Requester\Decorator\Authentication;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use Solido\Atlante\Http\HeaderBag;
+use Solido\Atlante\Requester\Decorator\Authentication\HttpBasicAuthenticator;
+use Solido\Atlante\Requester\Request;
+use function is_array;
+use function reset;
+
+class HttpBasicAuthenticatorTest extends TestCase
+{
+    /**
+     * @dataProvider provideDecorationCases
+     */
+    public function testDecoration(string $usernameOrEncodedAuth, ?string $password, ?string $givenAuthHeader, ?string $expectedAuthHeader): void
+    {
+        $decorator = new HttpBasicAuthenticator($usernameOrEncodedAuth, $password);
+        $request = new Request('GET', '/example.com', $givenAuthHeader === null ? null : ['authorization' => $givenAuthHeader], 'foo');
+
+        $decorated = $decorator->decorate($request);
+        $headers = $decorated->getHeaders();
+
+        $auth = $headers['authorization'] ?? null;
+        if (is_array($auth)) {
+            $auth = reset($auth);
+        }
+
+        self::assertEquals($expectedAuthHeader, $auth);
+        self::assertSame('GET', $decorated->getMethod());
+        self::assertSame('/example.com', $decorated->getUrl());
+        self::assertSame('foo', $decorated->getBody());
+    }
+
+    public static function provideDecorationCases(): Generator
+    {
+        yield ['1295AC56-C999-41C4-8384-B8D8D2D2F3AA', 'secret', null, 'Basic MTI5NUFDNTYtQzk5OS00MUM0LTgzODQtQjhEOEQyRDJGM0FBOnNlY3JldA=='];
+        yield ['1295AC56-C999-41C4-8384-B8D8D2D2F3AA', '', null, 'Basic MTI5NUFDNTYtQzk5OS00MUM0LTgzODQtQjhEOEQyRDJGM0FB'];
+        yield ['MTI5NUFDNTYtQzk5OS00MUM0LTgzODQtQjhEOEQyRDJGM0FBOnNlY3JldA==', null, null, 'Basic MTI5NUFDNTYtQzk5OS00MUM0LTgzODQtQjhEOEQyRDJGM0FBOnNlY3JldA=='];
+
+        yield ['1295AC56-C999-41C4-8384-B8D8D2D2F3AA', 'secret', 'fooAuth', 'fooAuth'];
+        yield ['1295AC56-C999-41C4-8384-B8D8D2D2F3AA', '', 'fooAuth', 'fooAuth'];
+        yield ['MTI5NUFDNTYtQzk5OS00MUM0LTgzODQtQjhEOEQyRDJGM0FBOnNlY3JldA==', null, 'fooAuth', 'fooAuth'];
+    }
+
+    /** @dataProvider provideHeaderDecorationCases */
+    public function testHeaderDecorationPreservePresets(?HeaderBag $given, HeaderBag $expected): void
+    {
+        $decorator = new HttpBasicAuthenticator('fooAuth');
+        $request = new Request('GET', '/example.com', $given === null ? $given : $given->all(), 'foo');
+
+        $decorated = $decorator->decorate($request);
+        self::assertEquals($expected->all(), $decorated->getHeaders());
+    }
+
+    public static function provideHeaderDecorationCases(): Generator
+    {
+        yield [new HeaderBag(['foo' => 'bar']), new HeaderBag(['foo' => 'bar', 'authorization' => 'Basic fooAuth'])];
+        yield [null, new HeaderBag(['authorization' => 'Basic fooAuth'])];
+    }
+}

--- a/tests/Requester/Response/BadResponsePropertyTreeTest.php
+++ b/tests/Requester/Response/BadResponsePropertyTreeTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Requester\Response;
+
+use Generator;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Solido\Atlante\Requester\Response\BadResponsePropertyTree;
+use Throwable;
+use function PHPUnit\Framework\assertCount;
+
+class BadResponsePropertyTreeTest extends TestCase
+{
+    /**
+     * @param object|array<string,mixed>|string $content
+     *
+     * @dataProvider provideParseCases
+     */
+    public function testParse($content): void
+    {
+        $parsed = BadResponsePropertyTree::parse($content);
+        self::assertInstanceOf(BadResponsePropertyTree::class, $parsed);
+        self::assertSame('', $parsed->getName());
+        self::assertEmpty($parsed->getErrors());
+        $children = $parsed->getChildren();
+        self::assertCount(2, $children);
+        foreach ($children as $child) {
+            self::assertInstanceOf(BadResponsePropertyTree::class, $child);
+        }
+
+        self::assertSame('foo', $children[0]->getName());
+        self::assertSame(['Required.'], $children[0]->getErrors());
+        self::assertEmpty($children[0]->getChildren());
+
+        self::assertSame('bar', $children[1]->getName());
+        self::assertEmpty($children[1]->getErrors());
+        $subchildren = $children[1]->getChildren();
+        assertCount(1, $subchildren);
+        foreach ($subchildren as $child) {
+            self::assertInstanceOf(BadResponsePropertyTree::class, $child);
+        }
+
+        self::assertSame('baz', $subchildren[0]->getName());
+        self::assertSame(['Bazbar'], $subchildren[0]->getErrors());
+        self::assertEmpty($subchildren[0]->getChildren());
+    }
+
+    public static function provideParseCases(): Generator
+    {
+        yield [
+            [
+                'name' => '',
+                'errors' => [],
+                'children' => [
+                    [
+                        'name' => 'foo',
+                        'errors' => ['Required.'],
+                    ],
+                    [
+                        'name' => 'bar',
+                        'errors' => [],
+                        'children' => [
+                            [
+                                'name' => 'baz',
+                                'errors' => ['Bazbar'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield [
+            ((object) [
+                'name' => '',
+                'errors' => [],
+                'children' => [
+                    ((object) [
+                        'name' => 'foo',
+                        'errors' => ['Required.'],
+                    ]),
+                    ((object) [
+                        'name' => 'bar',
+                        'errors' => [],
+                        'children' => [
+                            ((object) [
+                                'name' => 'baz',
+                                'errors' => ['Bazbar'],
+                            ]),
+                        ],
+                    ]),
+                ],
+            ]),
+        ];
+    }
+
+    /**
+     * @param object|array<string,mixed>|string $content
+     * @param string $exceptionClass
+     *
+     * @phpstan-param class-string<Throwable> $exceptionClass
+     * @dataProvider provideBadCases
+     */
+    public function testBadCases($content, $exceptionClass, ?string $message = null): void
+    {
+        $this->expectException($exceptionClass);
+        if ($message !== null) {
+            $this->expectExceptionMessage($message);
+        }
+
+        BadResponsePropertyTree::parse($content);
+    }
+
+    public static function provideBadCases(): Generator
+    {
+        yield ['foobar', InvalidArgumentException::class, 'Unexpected response type, object or array expected, string given'];
+        yield [['name' => 'foobar'], InvalidArgumentException::class, 'Unable to parse missing `errors` property'];
+        yield [['errors' => ['foobar']], InvalidArgumentException::class, 'Missing `name` property'];
+        yield [['name' => ['foo'], 'errors' => ['foobar']], InvalidArgumentException::class, 'Invalid `name` property type, expected string, array given'];
+        yield [['errors' => 'foo', 'name' => 'foobar'], InvalidArgumentException::class, 'Invalid `errors` property type, expected array, string given'];
+        yield [['name' => 'foobar', 'errors' => [], 'children' => 'foobar'], InvalidArgumentException::class, 'Invalid `children` property type, expected array, string given'];
+        yield [['name' => 'foobar', 'errors' => [], 'children' => ['foobar']], InvalidArgumentException::class, 'Unexpected response type, object or array expected, string given'];
+    }
+}

--- a/tests/Requester/Response/BadResponseTest.php
+++ b/tests/Requester/Response/BadResponseTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Requester\Response;
+
+use PHPUnit\Framework\TestCase;
+use Solido\Atlante\Requester\Response\BadResponse;
+use Solido\Atlante\Requester\Response\BadResponsePropertyTree;
+
+class BadResponseTest extends TestCase
+{
+    public function testCanCreate(): void
+    {
+        $response = new BadResponse([
+            'name' => 'foo',
+            'errors' => [],
+            'children' => [],
+        ]);
+
+        self::assertSame(400, $response->getStatusCode());
+
+        $errors = $response->getErrors();
+        self::assertInstanceOf(BadResponsePropertyTree::class, $errors);
+    }
+}

--- a/tests/Requester/Response/ResponseFactoryTest.php
+++ b/tests/Requester/Response/ResponseFactoryTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Requester\Response;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
+use Solido\Atlante\Requester\Response\BadResponse;
+use Solido\Atlante\Requester\Response\BadResponsePropertyTree;
+use Solido\Atlante\Requester\Response\InvalidResponse;
+use Solido\Atlante\Requester\Response\Response;
+use Solido\Atlante\Requester\Response\ResponseFactory;
+use Symfony\Contracts\HttpClient\ResponseInterface as SymfonyHttpClientResponse;
+use TypeError;
+use function assert;
+
+class ResponseFactoryTest extends TestCase
+{
+    /**
+     * @param SymfonyHttpClientResponse $requesterResponse
+     * @param object|string $expectedData
+     *
+     * @phpstan-param class-string $responseClassname
+     * @dataProvider provideParseCases
+     */
+    public function testFromResponse($requesterResponse, string $responseClassname, int $statusCode, $expectedData): void
+    {
+        $factory = new ResponseFactory();
+        $response = $factory->fromResponse($requesterResponse);
+        self::assertInstanceOf($responseClassname, $response);
+        self::assertEquals($statusCode, $response->getStatusCode());
+        self::assertEquals($expectedData, $response->getData());
+    }
+
+    public function provideParseCases(): Generator
+    {
+        foreach (['SfResponse', 'PsrResponse'] as $kind) {
+            $mockMethod = 'mock' . $kind;
+
+            $headers = [];
+            $statusCode = 200;
+            $content = 'foobar';
+
+            yield [$this->$mockMethod($statusCode, $content, $headers), InvalidResponse::class, $statusCode, $content];
+
+            $content = '{"_id":"foo"}';
+
+            yield [$this->$mockMethod($statusCode, $content, $headers), InvalidResponse::class, $statusCode, $content];
+
+            $headers = ['content-type' => 'application/json'];
+
+            yield [$this->$mockMethod($statusCode, $content, $headers), Response::class, $statusCode, (object) ['_id' => 'foo']];
+
+            $statusCode = 201;
+            $headers = ['content-type' => 'application/json'];
+
+            yield [$this->$mockMethod($statusCode, $content, $headers), Response::class, $statusCode, (object) ['_id' => 'foo']];
+
+            $statusCode = 400;
+            $content = '{"name":"foo","errors":["Required."],"children":[]}';
+
+            yield [
+                $this->$mockMethod($statusCode, $content, $headers),
+                BadResponse::class,
+                $statusCode,
+                BadResponsePropertyTree::parse([
+                    'name' => 'foo',
+                    'errors' => ['Required.'],
+                    'children' => [],
+                ]),
+            ];
+
+            $statusCode = 500;
+
+            yield [
+                $this->$mockMethod($statusCode, $content, $headers),
+                InvalidResponse::class,
+                $statusCode,
+                ((object) [
+                    'name' => 'foo',
+                    'errors' => ['Required.'],
+                    'children' => [],
+                ]),
+            ];
+        }
+    }
+
+    public function testUnexpectedResponse(): void
+    {
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('Argument 1 passed to Solido\Atlante\Requester\Response\ResponseFactory::decodeData has to be an instance of Psr\Http\Message\ResponseInterface or Symfony\Contracts\HttpClient\ResponseInterface, array passed');
+
+        $requesterResponse = [];
+        $factory = new ResponseFactory();
+        // @phpstan-ignore-next-line
+        $response = $factory->fromResponse($requesterResponse);
+    }
+
+    /**
+     * @param string[]|string[][] $headers
+     */
+    // @phpcs:ignore SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod
+    private function mockSfResponse(int $statusCode, string $content, array $headers): SymfonyHttpClientResponse
+    {
+        $response = $this->prophesize(SymfonyHttpClientResponse::class);
+
+        $response->getStatusCode()->willReturn($statusCode);
+        $response->getHeaders(Argument::cetera())->willReturn($headers);
+        $response->getContent(Argument::cetera())->willReturn($content);
+
+        $r = $response->reveal();
+        assert($r instanceof SymfonyHttpClientResponse);
+
+        return $r;
+    }
+
+    /**
+     * @param string[]|string[][] $headers
+     */
+    // @phpcs:ignore SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod
+    private function mockPsrResponse(int $statusCode, string $content, array $headers): PsrResponseInterface
+    {
+        $response = $this->prophesize(PsrResponseInterface::class);
+
+        $response->getStatusCode()->willReturn($statusCode);
+        $response->getHeaders(Argument::cetera())->willReturn($headers);
+        $response->getBody()->willReturn($content);
+
+        $r = $response->reveal();
+        assert($r instanceof PsrResponseInterface);
+
+        return $r;
+    }
+}


### PR DESCRIPTION
Add basic unit tests for:

- Decorators: `AcceptFallbackDecorator`, `HttpBasicAuthenticator`
- Response: `ResponseFactory`, `BadResponse` and `BadResponsePropertyTree`